### PR TITLE
adapt unbounded array size depending on 64/32 bit

### DIFF
--- a/wtsapi/syscall.go
+++ b/wtsapi/syscall.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"syscall"
 	"unsafe"
+	"math"
 
 	"github.com/gentlemanautomaton/winsession/infoclass"
 	"golang.org/x/sys/windows"
@@ -110,7 +111,7 @@ func EnumerateSessions(server syscall.Handle) (sessions []SessionEntry, err erro
 
 	// Cast the pointer to an unbounded array and then take a slice of
 	// suitable size from it
-	list := ((*[1 << 30]sessionEntry)(ptr))[0:count:count]
+	list := ((*[math.MaxInt]sessionEntry)(ptr))[0:count:count]
 
 	sessions = make([]SessionEntry, 0, count)
 	for _, s := range list {


### PR DESCRIPTION
syscall.go would failed to build on the 386 architecture, because the size of the unbounded array being too large for 32-bit architectures.
now the code uses math.MaxInt to change the size depending on the target architecture.